### PR TITLE
Fixes #2 Caching does not work

### DIFF
--- a/.github/actions/setup-qualification-environment/action.yml
+++ b/.github/actions/setup-qualification-environment/action.yml
@@ -7,7 +7,7 @@ runs:
 
     - name: Set R library path
       run: |
-        echo "R_LIBS_USER=D:\a\_temp\Library" >> $GITHUB_ENV
+        echo "R_LIBS_USER=${RUNNER_TEMP}\Library" >> $GITHUB_ENV
       shell: bash
 
     - name: Configure git, set cache key
@@ -41,6 +41,7 @@ runs:
       with:
         r-version: '${{ steps.get-tools-versions.outputs.r }}'
         use-public-rspm: true
+        rtools-version: 'none'
 
     - name: Setup Pandoc (cached run)
       if: steps.cache-setup.outputs.cache-hit == 'true'
@@ -68,6 +69,7 @@ runs:
     # Save the prepared environment so subsequent runs can skip setup
     - name: Save setup cache
       if: steps.cache-setup.outputs.cache-hit != 'true'
+      continue-on-error: true
       uses: actions/cache/save@v5
       with:
         key: ${{ env.CACHE_KEY }}

--- a/.github/actions/setup-qualification-environment/action.yml
+++ b/.github/actions/setup-qualification-environment/action.yml
@@ -5,11 +5,15 @@ runs:
   using: composite
   steps:
 
-    - name: Configure git, calculate hash of tools.csv and set R library path
+    - name: Set R library path
+      run: |
+        echo "R_LIBS_USER=D:\a\_temp\Library" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Configure git, set cache key
       run: |
         git config --global core.longpaths true
-        echo "R_LIBS_USER=${{ github.workspace }}/RLibrary" >> $GITHUB_ENV
-        echo "TOOLS_CSV_HASH=${{ hashFiles('tools.csv') }}" >> $GITHUB_ENV
+        echo "CACHE_KEY=ospsuite-${{ env.R_LIBS_USER }}-${{ hashFiles('tools.csv') }}" >> $GITHUB_ENV
       shell: bash
 
     # Restore previously prepared environment if tools.csv was unchanged
@@ -17,9 +21,9 @@ runs:
       id: cache-setup
       uses: actions/cache/restore@v5
       with:
-        key: ospsuite-${{ env.TOOLS_CSV_HASH }}
+        key: ${{ env.CACHE_KEY }}
         path: |
-          ${{ github.workspace }}/RLibrary
+          ${{ env.R_LIBS_USER }}
           ${{ github.workspace }}/PK-Sim
           ${{ github.workspace }}/QualificationRunner
 
@@ -66,8 +70,8 @@ runs:
       if: steps.cache-setup.outputs.cache-hit != 'true'
       uses: actions/cache/save@v5
       with:
-        key: ospsuite-${{ env.TOOLS_CSV_HASH }}
+        key: ${{ env.CACHE_KEY }}
         path: |
-          ${{ github.workspace }}/RLibrary
+          ${{ env.R_LIBS_USER }}
           ${{ github.workspace }}/PK-Sim
           ${{ github.workspace }}/QualificationRunner

--- a/.github/actions/setup-qualification-environment/action.yml
+++ b/.github/actions/setup-qualification-environment/action.yml
@@ -1,0 +1,73 @@
+name: 'Setup Qualification Environment'
+description: 'Sets up the qualification environment (R, PK-Sim, QualificationRunner) with caching support'
+
+runs:
+  using: composite
+  steps:
+
+    - name: Configure git, calculate hash of tools.csv and set R library path
+      run: |
+        git config --global core.longpaths true
+        echo "R_LIBS_USER=${{ github.workspace }}/RLibrary" >> $GITHUB_ENV
+        echo "TOOLS_CSV_HASH=${{ hashFiles('tools.csv') }}" >> $GITHUB_ENV
+      shell: bash
+
+    # Restore previously prepared environment if tools.csv was unchanged
+    - name: Restore setup cache
+      id: cache-setup
+      uses: actions/cache/restore@v5
+      with:
+        key: ospsuite-${{ env.TOOLS_CSV_HASH }}
+        path: |
+          ${{ github.workspace }}/RLibrary
+          ${{ github.workspace }}/PK-Sim
+          ${{ github.workspace }}/QualificationRunner
+
+    # Always compute the R version from tools.csv so we can install R on cached runs
+    - id: get-tools-versions
+      name: Get tools versions (for R setup on cached runs)
+      uses: Open-Systems-Pharmacology/Workflows/.github/actions/get-tools-versions@main
+      with:
+        tools-path: tools.csv
+
+    # If we restored the environment, we still need to make R, Pandoc, and chromehtml2pdf available
+    - name: Setup R (cached run)
+      if: steps.cache-setup.outputs.cache-hit == 'true'
+      uses: r-lib/actions/setup-r@v2
+      with:
+        r-version: '${{ steps.get-tools-versions.outputs.r }}'
+        use-public-rspm: true
+
+    - name: Setup Pandoc (cached run)
+      if: steps.cache-setup.outputs.cache-hit == 'true'
+      uses: r-lib/actions/setup-pandoc@v2
+
+    - name: Install chromehtml2pdf (cached run)
+      if: steps.cache-setup.outputs.cache-hit == 'true'
+      run: npm install -g chromehtml2pdf
+      shell: bash
+
+    - id: qualification-environment
+      if: steps.cache-setup.outputs.cache-hit != 'true'
+      name: Setup Qualification Environment
+      uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-qualification-environment@main
+      with:
+        tools-path: tools.csv
+
+    - name: Downgrade ggplot2 to 3.5.2
+      if: steps.cache-setup.outputs.cache-hit != 'true'
+      run: |
+        Rscript -e 'remove.packages("ggplot2")'
+        Rscript -e 'remotes::install_version("ggplot2", version = "3.5.2", repos = "https://cran.r-project.org")'
+      shell: bash
+
+    # Save the prepared environment so subsequent runs can skip setup
+    - name: Save setup cache
+      if: steps.cache-setup.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        key: ospsuite-${{ env.TOOLS_CSV_HASH }}
+        path: |
+          ${{ github.workspace }}/RLibrary
+          ${{ github.workspace }}/PK-Sim
+          ${{ github.workspace }}/QualificationRunner

--- a/.github/workflows/create-evaluation_reports.yml
+++ b/.github/workflows/create-evaluation_reports.yml
@@ -84,83 +84,13 @@ jobs:
       matrix: ${{ fromJSON(needs.read_inputs.outputs.models) }}
       fail-fast: false
     runs-on: windows-2022
-    env:
-      # Stable, workspace-local R library so we can cache it reliably
-      R_LIBS_USER: ${{ github.workspace }}/RLibrary
+    
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
-    
-    - name: Configure git
-      run: |
-        git config --global core.longpaths true
-      shell: bash
-
-    # Compute hash of tools.csv and export to environment for subsequent steps
-    - name: Compute tools.csv hash
-      id: compute-tools-hash
-      shell: bash
-      run: echo "TOOLS_CSV_HASH=${{ hashFiles('tools.csv') }}" >> $GITHUB_ENV
-
-    # Restore previously prepared environment if tools.csv was unchanged
-    - name: Restore setup cache
-      id: cache-setup
-      uses: actions/cache/restore@v5
-      with:
-        key: ospsuite-${{ env.TOOLS_CSV_HASH }}
-        path: |
-          ${{ env.R_LIBS_USER }}
-          ${{ github.workspace }}/PK-Sim
-          ${{ github.workspace }}/QualificationRunner
-
-    # Always compute the R version from tools.csv so we can install R on cached runs
-    - id: get-tools-versions
-      name: Get tools versions (for R setup on cached runs)
-      uses: Open-Systems-Pharmacology/Workflows/.github/actions/get-tools-versions@main
-      with:
-        tools-path: tools.csv
-
-    # If we restored the environment, we still need to make R, Pandoc, and chromehtml2pdf available
-    - name: Setup R (cached run)
-      if: steps.cache-setup.outputs.cache-hit == 'true'
-      uses: r-lib/actions/setup-r@v2
-      with:
-        r-version: '${{ steps.get-tools-versions.outputs.r }}'
-        use-public-rspm: true
-
-    - name: Setup Pandoc (cached run)
-      if: steps.cache-setup.outputs.cache-hit == 'true'
-      uses: r-lib/actions/setup-pandoc@v2
-
-    - name: Install chromehtml2pdf (cached run)
-      if: steps.cache-setup.outputs.cache-hit == 'true'
-      run: npm install -g chromehtml2pdf
-      shell: bash
-
-    - id: qualification-environment
-      name: Setup Qualification Environment
-      if: steps.cache-setup.outputs.cache-hit != 'true'
-      uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-qualification-environment@main
-      with:
-        tools-path: tools.csv
-
-    - name: Downgrade ggplot2 to 3.5.2
-      if: steps.cache-setup.outputs.cache-hit != 'true'
-      run: |
-        Rscript -e 'remove.packages("ggplot2")'
-        Rscript -e 'remotes::install_version("ggplot2", version = "3.5.2", repos = "https://cran.r-project.org")'
-      shell: bash
-
-    # Save the prepared environment so subsequent runs can skip setup
-    - name: Save setup cache
-      if: steps.cache-setup.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v5
-      with:
-        key: ospsuite-${{ env.TOOLS_CSV_HASH }}
-        path: |
-          ${{ env.R_LIBS_USER }}
-          ${{ github.workspace }}/PK-Sim
-          ${{ github.workspace }}/QualificationRunner
+      
+    - name: Setup Qualification Environment
+      uses: ./.github/actions/setup-qualification-environment
 
     - id: run-model-evaluation
       name: Run evaluation
@@ -208,6 +138,4 @@ jobs:
           ## All evaluated models
           ${{ needs.read_inputs.outputs.models_table }}
 #        reviewers: ${{ github.actor }}
-
-
 

--- a/.github/workflows/create-qualification_reports.yml
+++ b/.github/workflows/create-qualification_reports.yml
@@ -84,77 +84,13 @@ jobs:
       matrix: ${{ fromJSON(needs.read_inputs.outputs.qualifications) }}
       fail-fast: false
     runs-on: windows-2022
-    env:
-      # Stable, workspace-local R library so we can cache it reliably
-      R_LIBS_USER: ${{ github.workspace }}/RLibrary
+    
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
-    
-    - name: Configure git
-      run: |
-        git config --global core.longpaths true
-      shell: bash
-
-    # Restore previously prepared environment if tools.csv was unchanged
-    - name: Restore setup cache
-      id: cache-setup
-      uses: actions/cache/restore@v5
-      with:
-        key: ospsuite-${{ hashFiles('tools.csv') }}
-        path: |
-          ${{ env.R_LIBS_USER }}
-          ${{ github.workspace }}/PK-Sim
-          ${{ github.workspace }}/QualificationRunner
-
-    # Always compute the R version from tools.csv so we can install R on cached runs
-    - id: get-tools-versions
-      name: Get tools versions (for R setup on cached runs)
-      uses: Open-Systems-Pharmacology/Workflows/.github/actions/get-tools-versions@main
-      with:
-        tools-path: tools.csv
-
-    # If we restored the environment, we still need to make R, Pandoc, and chromehtml2pdf available
-    - name: Setup R (cached run)
-      if: steps.cache-setup.outputs.cache-hit == 'true'
-      uses: r-lib/actions/setup-r@v2
-      with:
-        r-version: '${{ steps.get-tools-versions.outputs.r }}'
-        use-public-rspm: true
-
-    - name: Setup Pandoc (cached run)
-      if: steps.cache-setup.outputs.cache-hit == 'true'
-      uses: r-lib/actions/setup-pandoc@v2
-
-    - name: Install chromehtml2pdf (cached run)
-      if: steps.cache-setup.outputs.cache-hit == 'true'
-      run: npm install -g chromehtml2pdf
-      shell: bash
-
-    - id: qualification-environment
-      if: steps.cache-setup.outputs.cache-hit != 'true'
-      name: Setup Qualification Environment
-      uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-qualification-environment@main
-      with:
-        tools-path: tools.csv
-
-    - name: Downgrade ggplot2 to 3.5.2
-      if: steps.cache-setup.outputs.cache-hit != 'true'
-      run: |
-        Rscript -e 'remove.packages("ggplot2")'
-        Rscript -e 'remotes::install_version("ggplot2", version = "3.5.2", repos = "https://cran.r-project.org")'
-      shell: bash
-
-    # Save the prepared environment so subsequent runs can skip setup
-    - name: Save setup cache
-      if: steps.cache-setup.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v5
-      with:
-        key: ospsuite-${{ hashFiles('tools.csv') }}
-        path: |
-          ${{ env.R_LIBS_USER }}
-          ${{ github.workspace }}/PK-Sim
-          ${{ github.workspace }}/QualificationRunner
+      
+    - name: Setup Qualification Environment
+      uses: ./.github/actions/setup-qualification-environment
 
     - id: run-qualification
       name: Run qualification


### PR DESCRIPTION
Extracted the common "Setup OSP Infrastructure" part from the 2 workflows (should be moved later to the Workflows repo).
Fixes #2 Caching does not work.

Now when executed for the 1st time from a new branch (or after changing of tools.csv configuration) - a new cache is created and used in the subsequent runs from this branch (saves 6-7 minutes per qualification run).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined internal CI/CD setup processes to improve build reliability and maintainability through centralized environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->