### PR TITLE
Run from main

### DIFF
--- a/.github/workflows/create-evaluation_reports.yml
+++ b/.github/workflows/create-evaluation_reports.yml
@@ -17,18 +17,7 @@ env:
   GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  check-branch:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Validate source branch
-      run: |
-        if [ "${{ github.ref_name }}" = "main" ]; then
-          echo "::error::Please call the workflow not from the main branch"
-          exit 1
-        fi
-
   read_inputs:
-    needs: check-branch
     runs-on: ubuntu-latest
     outputs:
       tools_table: ${{ steps.tools_table.outputs.tools-table }}

--- a/.github/workflows/create-qualification_reports.yml
+++ b/.github/workflows/create-qualification_reports.yml
@@ -17,18 +17,7 @@ env:
   GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  check-branch:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Validate source branch
-      run: |
-        if [ "${{ github.ref_name }}" = "main" ]; then
-          echo "::error::Please call the workflow not from the main branch"
-          exit 1
-        fi
-
   read_inputs:
-    needs: check-branch
     runs-on: ubuntu-latest
     outputs:
       tools_table: ${{ steps.tools_table.outputs.tools-table }}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
   <img width="600" alt="image" src="https://github.com/user-attachments/assets/e120663e-0916-4c79-b0eb-b16034601b9c" />
 
+* In the forked repository settings (category **Actions**▶️**General**) activate the option `Allow GitHub Actions to create and approve pull requests` (s. [Workflow permissions](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#preventing-github-actions-from-creating-or-approving-pull-requests) in the GitHub documentation for details).
+
+  <img width="600" src="https://github.com/user-attachments/assets/b9977f37-e9b4-4a93-8dc2-24f592e2d973" />
+
 * [OPTIONAL] Synchronize the `main` branch of your fork with the parent OSP repository if required <br>(see [Syncing a fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork) in the GitHub documentation for details).
 
 ## Notes
@@ -22,8 +26,8 @@
    * Click the __Run workflow__ button 
    * [OPTIONAL] Adjust the commit message that will appear later in the created pull request<br>(see the [What to do when reports are created](#next-step) section below).
    * Click the green __Run workflow__ button
-     
-        <img width="800" alt="Run workflow dialog showing branch selection and commit message options" src="https://github.com/user-attachments/assets/d787ddc6-db2a-47c0-ab98-82bcb0051bb4" />
+  
+        <img width="700" src="https://github.com/user-attachments/assets/b2c02567-4448-4196-b0bb-1367ab46ecce" />
 
 ## How to create qualification reports
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 * In the forked repository settings (category **Actions**▶️**General**) activate the option `Allow GitHub Actions to create and approve pull requests` (s. [Workflow permissions](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#preventing-github-actions-from-creating-or-approving-pull-requests) in the GitHub documentation for details).
 
-  <img width="600" src="https://github.com/user-attachments/assets/b9977f37-e9b4-4a93-8dc2-24f592e2d973" />
+  <img width="600" alt="Fork Actions → General setting for allowing GitHub Actions to create and approve pull requests" src="https://github.com/user-attachments/assets/b9977f37-e9b4-4a93-8dc2-24f592e2d973" />
 
 * [OPTIONAL] Synchronize the `main` branch of your fork with the parent OSP repository if required <br>(see [Syncing a fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork) in the GitHub documentation for details).
 
@@ -27,7 +27,7 @@
    * [OPTIONAL] Adjust the commit message that will appear later in the created pull request<br>(see the [What to do when reports are created](#next-step) section below).
    * Click the green __Run workflow__ button
   
-        <img width="700" src="https://github.com/user-attachments/assets/b2c02567-4448-4196-b0bb-1367ab46ecce" />
+        <img width="700" alt="Screenshot showing the GitHub Actions 'Run workflow' button for creating evaluation reports" src="https://github.com/user-attachments/assets/b2c02567-4448-4196-b0bb-1367ab46ecce" />
 
 ## How to create qualification reports
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,12 @@
 
 ## How to create model evaluation reports
 
-1. Create a new branch (e.g. `my-reports`) from the `main` branch of your fork (see [Creating a branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository#creating-a-branch)).
 1. Define the models by updating [`models.csv`](models.csv) (see the [Models](#models) section below for details)
-   * Once you are finished, push the new branch to your fork and verify that the check [Validate models.csv](../../actions/workflows/check-models.yml) was successful!
+   * Once you are finished, verify that the check [Validate models.csv](../../actions/workflows/check-models.yml) was successful!
 1. [OPTIONAL] Adjust the OSP environment and tools by updating [`tools.csv`](tools.csv)<br>(see the [Tools](#tools) section below for details)
    * In case of modifications: verify that the check [Validate tools.csv](../../actions/workflows/check-tools.yml) was successful!
 1. Go to the GitHub Action: [Create evaluation reports and projects](../../actions/workflows/create-evaluation_reports.yml)<br><br>
    * Click the __Run workflow__ button 
-   * Select the branch defined in the first step (for instance, `my-reports`)
    * [OPTIONAL] Adjust the commit message that will appear later in the created pull request<br>(see the [What to do when reports are created](#next-step) section below).
    * Click the green __Run workflow__ button
      
@@ -29,20 +27,18 @@
 
 ## How to create qualification reports
 
-1. Create a new branch (e.g. `my-reports`) from the `main` branch of your fork.
 1. Define the qualifications by updating [`qualifications.csv`](qualifications.csv) (see the [Qualifications](#qualifications) section below for details)
-   * Once you are finished, push the new branch to your fork and verify that the check [Validate qualifications.csv](../../actions/workflows/check-qualifications.yml) was successful!
+   * Once you are finished, verify that the check [Validate qualifications.csv](../../actions/workflows/check-qualifications.yml) was successful!
 1. [OPTIONAL] Adjust the OSP environment and tools by updating [`tools.csv`](tools.csv)<br>(see the [Tools](#tools) section below for details)
     * In case of modifications: verify that the check [Validate tools.csv](../../actions/workflows/check-tools.yml) was successful!
 1. Go to the GitHub Action: [Create qualification reports](../../actions/workflows/create-qualification_reports.yml)
     * Click the __Run workflow__ button 
-    * Select the branch defined in the first step (for instance, `my-reports`)
     * [OPTIONAL] Adjust the commit message that will appear later in the created pull request<br>(see the [What to do when reports are created](#next-step) section below).
     * Click the green __Run workflow__ button 
 
 ## What to do when reports are created<a id="next-step"></a>
 
-When qualification reports are created, pull requests (PRs) are created (one PR for each qualification report) toward the branch defined in the first step (for instance, `my-reports`).<br>
+When qualification reports are created, pull requests (PRs) are created (one PR for each qualification report).<br>
 These pull requests allow users to review report updates and adopt the new version.
 For each created PR:
 * Close and reopen the PR: this will trigger the automated checks (e.g. links and cross-references) of the created report.
@@ -82,7 +78,7 @@ The header includes the following fields:
 > [!TIP]
 > Leave the cell blank if the default path, `Qualification/workflow.R`, is used (this path is case insensitive).
 - __Folder name__: Name of the target folder where the qualification report should be created.
- 
+
 ## Tools 
 
 The [`tools.csv`](tools.csv) file indicates the software and versions to be installed in the environment before running model qualifications.


### PR DESCRIPTION
Remove the requirement for creation of extra branches (some users were confused) and allow running the reports directly from the main branch.

Also added a prerequisite in Readme.md (allowing PR-creation by GHA)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Report generation workflows now execute without branch restrictions, allowing evaluation and qualification reports to be created from any branch.

* **Documentation**
  * Simplified report creation instructions by removing the separate branch workflow requirement.
  * Added repository setup requirement: enable GitHub Actions permissions for pull request creation and approval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->